### PR TITLE
fix: skip MTP streaming hook for image/audio embed ubatches

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3217,6 +3217,13 @@ void llama_context::handle_mtp_for_ubatch(
     if (n_tokens == 0 || t == nullptr) {
         return;
     }
+    // Skip embed-only ubatches (e.g. image/audio chunks from mtmd): the MTP
+    // head needs token ids paired with hidden states, and we have none here.
+    // pending_pos is left untouched so it self-resets via !pending_continues
+    // when the next text ubatch arrives at a non-adjacent position.
+    if (tokens == nullptr) {
+        return;
+    }
     if (t->ne[1] != (int64_t) n_tokens) {
         return;
     }


### PR DESCRIPTION
## Description
When using `--spec-type mtp` with multimodal models (e.g., Qwen3.6 + mmproj), the server crashes with a segfault or memory exhaustion during image/audio decoding. This happens because the MTP speculative decoding hook runs unconditionally after every trunk ubatch, including embedding-only batches where `ubatch.tokens` is `nullptr`.

## Root Cause
- `handle_mtp_for_ubatch` assumes token IDs are available alongside hidden states to draft next tokens.
- For vision/audio inputs, the trunk only emits embeddings (`ubatch.embd`), leaving `ubatch.tokens == nullptr`.
- The hook blindly dereferences `tokens[k+1]`, triggering a segfault.
- The preceding `find_slot: non-consecutive token position` warnings are a side effect of M-RoPE positioning in the trunk’s recurrent memory and are not the cause of the crash.

## Fix
Added an early return in `handle_mtp_for_ubatch` (`src/llama-context.cpp`) when `tokens == nullptr`. The MTP head cannot generate drafts for embedding-only batches anyway. The existing `pending_pos` state naturally resets when the next text ubatch arrives at a non-adjacent position, so no extra cleanup is required.

## Testing
- **Repro:** `--spec-type mtp --spec-draft-n-max 3` + Qwen3.6-35B-A3B + mmproj + image input
- **Before:** Server segfaults / enters infinite `find_slot` loop consuming VRAM/RAM
- **After:** Image batch processes successfully, MTP resumes correctly on subsequent text tokens
- Verified locally with `cmake --build build -j --config Release` (clean build, no warnings)
- No regressions observed in standard text-only MTP flows

## References
- Fixes #22867
- Relates to PR #22673 (MTP Support)


<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

AI assisted with initial debugging and patch formulation. Root cause analysis, code verification, and local testing were performed and validated by the author.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
