### PR TITLE
convert: infer Qwen3.5/3.6 mtp_num_hidden_layers from safetensors

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5463,6 +5463,31 @@ class _Qwen35MtpMixin:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Upstream Qwen3.6 repos (Qwen/Qwen3.6-27B, Qwen/Qwen3.6-35B-A3B) ship
+        # MTP weights under `mtp.*` but do not set `mtp_num_hidden_layers` in
+        # config.json. Without this hparam the mixin silently drops the entire
+        # MTP block at conversion time, producing a GGUF that fails to load
+        # later with `GGML_ASSERT(nextn_predict_layers > 0)` when `--spec-type
+        # mtp` is requested. Infer it from the safetensors weight map so the
+        # converter works on un-patched HF repos.
+        if not self.hparams.get("mtp_num_hidden_layers"):
+            wm_keys: Iterable[str] = ()
+            idx = self.dir_model / "model.safetensors.index.json"
+            if idx.is_file():
+                wm_keys = json.loads(idx.read_text()).get("weight_map", {}).keys()
+            else:
+                sf = self.dir_model / "model.safetensors"
+                if sf.is_file():
+                    with open(sf, "rb") as _f:
+                        _n = int.from_bytes(_f.read(8), "little")
+                        wm_keys = json.loads(_f.read(_n).decode("utf-8")).keys()
+            ids = {int(m.group(1)) for k in wm_keys for m in [re.match(r"mtp\.layers\.(\d+)\.", k)] if m}
+            if ids:
+                self.hparams["mtp_num_hidden_layers"] = max(ids) + 1
+                logger.warning(
+                    f"inferred mtp_num_hidden_layers={self.hparams['mtp_num_hidden_layers']} "
+                    f"from safetensors weight_map (HF config.json missing this key)."
+                )
         self.block_count = self.hparams["num_hidden_layers"] + self.hparams.get("mtp_num_hidden_layers", 0)
         self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)
 


### PR DESCRIPTION
## Summary

Upstream Qwen3.6 repos ([Qwen/Qwen3.6-27B](https://huggingface.co/Qwen/Qwen3.6-27B), [Qwen/Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B)) ship the MTP block weights under `mtp.*` in the safetensors shards but **do not set `mtp_num_hidden_layers` in `config.json`**. The current `_Qwen35MtpMixin` reads this hparam from the config to decide whether to extend `block_count` and emit `nextn_predict_layers`. When the key is missing the entire MTP block is silently dropped at conversion time, producing a GGUF that boots fine for plain inference but fails at load with

```
GGML_ASSERT(hparams.nextn_predict_layers > 0 && "QWEN35_MTP requires nextn_predict_layers > 0") failed
```

as soon as the user passes `--spec-type mtp`.

This is what is happening in HF discussion reports against unsloth and other community uploaders: [unsloth/Qwen3.6-27B-GGUF-MTP#1](https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP/discussions/1), [unsloth/Qwen3.6-27B-GGUF-MTP#2](https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP/discussions/2), `lyf/Qwen3.6-27B-uncensored-heretic-v2-NVFP4-MTP`, `llmfan46/Qwen3.6-27B-uncensored-heretic-v2-NVFP4-MTP-GGUF`. Anyone converting an unmodified upstream Qwen3.6 repo today gets an MTP-less GGUF without any warning, and the failure only surfaces on the consumer side.

## Fix

Infer `mtp_num_hidden_layers` from the safetensors weight map at the top of `_Qwen35MtpMixin.__init__`:

1. Read `model.safetensors.index.json` if present; otherwise peek at the bare `model.safetensors` header for single-shard repos.
2. Count unique `mtp.layers.{N}.` indices and inject `mtp_num_hidden_layers = max(N) + 1` into `self.hparams`.
3. Log a warning when the value is inferred so the user is aware.

Everything downstream (`block_count` extension, `add_nextn_predict_layers`, the `mtp.fc` / `mtp.pre_fc_norm_*` / `mtp.norm` -> per-block `eh_proj` / `enorm` / `hnorm` / `shared_head.norm` fan-out) runs unchanged.

No behavioural change for repos that already set `mtp_num_hidden_layers` (the guard is `if not self.hparams.get(...)`).

## Test plan

- [x] Syntax check on `convert_hf_to_gguf.py`.
- [x] Unit-level check of the detection logic against a synthesised `weight_map` containing `mtp.layers.0.*` keys: correctly returns `mtp_num_hidden_layers = 1`.
- [x] End-to-end conversion of `Qwen/Qwen3.6-27B` and `Qwen/Qwen3.6-35B-A3B` (both unmodified) on the patched branch: resulting GGUFs carry `qwen35.block_count = 65` / `qwen35moe.block_count = 41`, `nextn_predict_layers = 1`, and the four `blk.{N}.nextn.*` tensors at the MTP slot.
- [x] `llama-server --spec-type mtp --spec-draft-n-max 3` loads the resulting files and decodes with non-zero draft acceptance (Qwen3.6-27B around 0.74, Qwen3.6-35B-A3B around 0.78 on a small B200 prompt set).

## Followups (not in this PR)

- Replace the bare `GGML_ASSERT` at `src/models/qwen35_mtp.cpp:8` with a clear error message pointing at the converter-side cause, so consumers of pre-existing broken GGUFs get a useful pointer instead of a stack trace. Happy to send as a separate PR.
- Encourage Qwen to add `mtp_num_hidden_layers: 1` to the upstream `config.json` files so this converter-side workaround can eventually be dropped.

cc @am17an