### PR TITLE
spec : fix compatibility with n-gram and add TODOs

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -7,6 +7,7 @@
 #include "log.h"
 #include "llama.h"
 #include "sampling.h"
+#include "speculative.h"
 #include "unicode.h"
 
 #include <algorithm>
@@ -1245,6 +1246,29 @@ common_init_result::common_init_result(common_params & params) :
     if (params.sampling.backend_sampling) {
         cparams.samplers   = pimpl->samplers_seq_config.data();
         cparams.n_samplers = pimpl->samplers_seq_config.size();
+    }
+
+    // [TAG_RS_STATE_ROLLBACK_SUPPORT]
+    // TODO: ngram speculative methods require checkpointing in addition to partial RS rollback
+    //       currently this is not supported. so we disable the partial rollback
+    if (cparams.n_rs_seq > 0 && (llama_model_is_recurrent(model) || llama_model_is_hybrid(model))) {
+        auto & types = params.speculative.types;
+
+        for (int i = 0; i < (int) types.size(); i++) {
+            if (types[i] == COMMON_SPECULATIVE_TYPE_NONE) {
+                continue;
+            }
+            if (types[i] == COMMON_SPECULATIVE_TYPE_DRAFT_MTP) {
+                continue;
+            }
+
+            cparams.n_rs_seq = 0;
+
+            LOG_WRN("%s: recurrent state rollback is not compatible with '%s' - disabling rollback support\n", __func__,
+                    common_speculative_type_to_str(types[i]).c_str());
+
+            break;
+        }
     }
 
     llama_context * lctx = llama_init_from_model(model, cparams);

--- a/common/common.h
+++ b/common/common.h
@@ -303,7 +303,7 @@ struct common_params_speculative_draft {
     int32_t n_min = 0;  // minimum number of draft tokens to use for speculative decoding
 
     float p_split = 0.1f;  // speculative decoding split probability
-    float p_min   = 0.75f; // minimum speculative decoding probability (greedy)
+    float p_min   = 0.75f; // minimum speculative decoding probability (greedy) // TODO: change default to 0.0f
 
     common_params_model mparams;
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1497,7 +1497,8 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id seq_id, u
     // TODO: currently only the implementation that generated the draft is used to accept it
     //       however, some implementations (such as MTP) need to also "see" the accepted tokens
     //       extend `common_speculative_impl::accept()` with an extra argument `bool is_other` to
-    //       inform the implementation if the accepted tokens are from another implementation
+    //       inform the implementation if the accepted tokens are from another implementation and
+    //       pass the accepted tokens to all remaining implementations using `is_other == true`
     {
         common_time_meas tm(impl->t_accept_us, !impl->gen_perf);
         if (n_accepted > 0) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -424,7 +424,7 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
         for (auto & s : smpls) {
             common_params_sampling sparams;
             sparams.no_perf  = false;
-            sparams.top_k    = 1;
+            sparams.top_k    = 1; // TODO: re-enable top_k == 10 and utilize `p_min` spec param
             sparams.samplers = { COMMON_SAMPLER_TYPE_TOP_K };
             s.reset(common_sampler_init(llama_get_model(ctx_dft), sparams));
         }
@@ -1494,6 +1494,10 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id seq_id, u
 
     GGML_ASSERT(impl);
 
+    // TODO: currently only the implementation that generated the draft is used to accept it
+    //       however, some implementations (such as MTP) need to also "see" the accepted tokens
+    //       extend `common_speculative_impl::accept()` with an extra argument `bool is_other` to
+    //       inform the implementation if the accepted tokens are from another implementation
     {
         common_time_meas tm(impl->t_accept_us, !impl->gen_perf);
         if (n_accepted > 0) {

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2531,7 +2531,7 @@ kernel void kernel_rwkv_wkv7_f32(
 
 constant short FC_gated_delta_net_ne20 [[function_constant(FC_GATED_DELTA_NET + 0)]];
 constant short FC_gated_delta_net_ne30 [[function_constant(FC_GATED_DELTA_NET + 1)]];
-constant short FC_gated_delta_net_K     [[function_constant(FC_GATED_DELTA_NET + 2)]];
+constant short FC_gated_delta_net_K    [[function_constant(FC_GATED_DELTA_NET + 2)]];
 
 #if 1
 template<short NSG>
@@ -2549,6 +2549,7 @@ kernel void kernel_gated_delta_net_impl(
         uint3   ntg[[threads_per_threadgroup]])  {
 #define S_v FC_gated_delta_net_ne20
 #define G   FC_gated_delta_net_ne30
+#define K   FC_gated_delta_net_K
 
     const uint tx = tpitg.x;
     const uint ty = tpitg.y;
@@ -2561,8 +2562,6 @@ kernel void kernel_gated_delta_net_impl(
     const uint i11 = i21 % args.ne11;
 
     const float scale = 1.0f / sqrt((float)S_v);
-
-    const uint K = FC_gated_delta_net_K;
 
     // input state layout (D, K, n_seqs): per-seq stride is K*H*D; we read slot 0.
     // state is stored transposed: M[i20][is] = S[is][i20], so row i20 is contiguous
@@ -2666,6 +2665,7 @@ kernel void kernel_gated_delta_net_impl(
 
 #undef S_v
 #undef G
+#undef K
 }
 
 typedef decltype(kernel_gated_delta_net_impl<4>) kernel_gated_delta_net_t;

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -743,7 +743,7 @@ void llama_memory_recurrent::state_write(llama_io_write_i & io, llama_seq_id seq
         cell_ranges.emplace_back(cell_range_begin, size);
     }
 
-    if (flags % LLAMA_STATE_SEQ_FLAGS_ON_DEVICE && cell_ranges.size() > 1) {
+    if ((flags & LLAMA_STATE_SEQ_FLAGS_ON_DEVICE) && cell_ranges.size() > 1) {
         GGML_ABORT("cannot save/load multiple ranges of cells to/from device memory\n");
     }
 

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -719,6 +719,15 @@ size_t llama_memory_recurrent::size_s_bytes() const {
 void llama_memory_recurrent::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {
     GGML_UNUSED(flags);
 
+    // [TAG_RS_STATE_ROLLBACK_SUPPORT]
+    if (n_rs_seq != 0) {
+        for (uint32_t i = 0; i < rs_idx.size(); ++i) {
+            if (rs_idx[i] != 0) {
+                GGML_ABORT("recurrent state read/write is not supported with partial rollback");
+            }
+        }
+    }
+
     std::vector<std::pair<uint32_t, uint32_t>> cell_ranges; // ranges, from inclusive, to exclusive
     uint32_t cell_count = 0;
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -750,6 +750,35 @@ private:
 
         add_bos_token = llama_vocab_get_add_bos(vocab);
 
+        // [TAG_RS_STATE_ROLLBACK_SUPPORT]
+        // TODO: ngram speculative methods require checkpointing in addition to partial RS rollback
+        //       currently this is not supported. so we enable partial rollback only when MTP runs on its own
+        //       in this case, we don't have to do checkpoints to perform speculative decoding
+        if (llama_n_rs_seq(ctx_tgt) > 0) {
+            bool print_warning = true;
+
+            auto & types = params_base.speculative.types;
+
+            // filter all non-MTP speculative types
+            for (int i = 0; i < (int) params_base.speculative.types.size(); i++) {
+                if (types[i] == COMMON_SPECULATIVE_TYPE_NONE) {
+                    continue;
+                }
+                if (types[i] != COMMON_SPECULATIVE_TYPE_DRAFT_MTP) {
+                    if (print_warning && !types.empty()) {
+                        SRV_WRN("%s", "partial recurrent rollback is enabled, only MTP speculative decoding is supported\n");
+                    }
+
+                    SRV_WRN("removing speculative type %d (%s) from speculative types\n",
+                            types[i], common_speculative_type_to_str(types[i]).c_str());
+                    types.erase(types.begin() + i);
+
+                    print_warning = false;
+                    i--;
+                }
+            }
+        }
+
         if (params_base.speculative.has_dft()) {
             // TODO speculative: move to common/speculative.cpp?
             const auto & params_spec = params_base.speculative.draft;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -752,8 +752,7 @@ private:
 
         // [TAG_RS_STATE_ROLLBACK_SUPPORT]
         // TODO: ngram speculative methods require checkpointing in addition to partial RS rollback
-        //       currently this is not supported. so we enable partial rollback only when MTP runs on its own
-        //       in this case, we don't have to do checkpoints to perform speculative decoding
+        //       currently this is not supported. so we remove the non-MTP types from the list
         if (llama_n_rs_seq(ctx_tgt) > 0) {
             bool print_warning = true;
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -750,34 +750,6 @@ private:
 
         add_bos_token = llama_vocab_get_add_bos(vocab);
 
-        // [TAG_RS_STATE_ROLLBACK_SUPPORT]
-        // TODO: ngram speculative methods require checkpointing in addition to partial RS rollback
-        //       currently this is not supported. so we remove the non-MTP types from the list
-        if (llama_n_rs_seq(ctx_tgt) > 0) {
-            bool print_warning = true;
-
-            auto & types = params_base.speculative.types;
-
-            // filter all non-MTP speculative types
-            for (int i = 0; i < (int) params_base.speculative.types.size(); i++) {
-                if (types[i] == COMMON_SPECULATIVE_TYPE_NONE) {
-                    continue;
-                }
-                if (types[i] != COMMON_SPECULATIVE_TYPE_DRAFT_MTP) {
-                    if (print_warning && !types.empty()) {
-                        SRV_WRN("%s", "partial recurrent rollback is enabled, only MTP speculative decoding is supported\n");
-                    }
-
-                    SRV_WRN("removing speculative type %d (%s) from speculative types\n",
-                            types[i], common_speculative_type_to_str(types[i]).c_str());
-                    types.erase(types.begin() + i);
-
-                    print_warning = false;
-                    i--;
-                }
-            }
-        }
-
         if (params_base.speculative.has_dft()) {
             // TODO speculative: move to common/speculative.cpp?
             const auto & params_spec = params_base.speculative.draft;


### PR DESCRIPTION
### Sample commands

These are some sample commands to get started with MTP:

```bash
# MTP with draft size N (values for N: 2,3,...)
llama-server -hf [model-with-mtp] --spec-type draft-mtp --spec-draft-n-max 2

# add `--no-mmproj` to disable vision support if not needed (uses less memory)
llama-server ... --no-mmproj

# [ADVANCED]
# combine MTP + ngram-* (experimental, suitable for non-CUDA systems)
# use these combinations only if you know what you are doing 
llama-server -hf [model-with-mtp] \
  --spec-type draft-mtp --spec-draft-n-max 3 \
  --spec-type ngram-mod --spec-ngram-mod-n-match 24 --spec-ngram-mod-n-min 48 --spec-ngram-mod-n-max 64

# (same as above, but shorter)
llama-server -hf [model-with-mtp] --spec-default --spec-type draft-mtp --spec-draft-n-max 2
```

> [!TIP]
> MTP is compatible with Vision input.

> [!NOTE]
> Prompt processing (PP) speed typically takes a negative hit when MTP is enabled mainly due to Device-To-Host (D2H) embedding transfers. It's something to be optimized in the future.

> [!NOTE]
> Parallel decoding with MTP is supported, but not fully optimized yet.

### Models

- https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF
- https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF

### Quality check

The results from 4 runs of the AIME2026 eval (4x30 questions in total) with MTP enabled, using [llama-eval](https://github.com/ggml-org/llama.cpp/tree/master/examples/llama-eval), are within expectation and match the [reported value by Qwen team](https://huggingface.co/Qwen/Qwen3.6-27B#benchmark-results).

<img width="1160" height="821" alt="image" src="https://github.com/user-attachments/assets/cae5631f-2ff5-47ea-87bf-c3f26851ca04" />

Full data: [aime2026-qwen3.6-27b-mtp-q4_k-x4.json.html](https://github.com/user-attachments/files/27798291/aime2026-qwen3.6-27b-mtp-q4_k-x4.json.html)